### PR TITLE
fixed toggle error

### DIFF
--- a/src/roles.ts
+++ b/src/roles.ts
@@ -35,7 +35,7 @@ export class goldenContainer extends goldenItem {
 		}
 		var ci = this.glObject;
 		if(ci)
-			ci.addChild(child, ci.header.tabs.length);
+			ci.addChild(child);
 		else
 			this.config.content.push(child);
 	}
@@ -105,7 +105,9 @@ export class goldenChild extends goldenItem {
 	}
 	beforeDestroy() {
 		if(this.glObject)   //It can be destroyed in reaction of the removal of the glObject too
-			this.$parent.removeGlChild(this.glParent.glChildren.indexOf(this));
+		{
+			this.glObject.parent.removeChild(this.glObject);
+		}
 	}
 	@Watch('glObject') @Emit() destroy(v) { return !v; }
 


### PR DESCRIPTION
**Removed `ci.header.tabs.length` when adding child.** 
This is because the glObject in the context of adding a new child is not necessarily a stack. In this case, it is a glComponent which translates into a golden layout component.


**Rewrote `this.$parent.removeGlChild(this.glParent.glChildren.indexOf(this));` into `this.glObject.parent.removeChild(this.glObject);`** 
The reason here that golden layout automatically creates a stack inside a row or column to hold componennts. The created stack has no vueObject associated with it. So we are accessing the parent of the golden layout and remove from its children.

